### PR TITLE
solidify

### DIFF
--- a/apps/demo/src/Chart.tsx
+++ b/apps/demo/src/Chart.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
-import { createSignal } from 'solid-js'
-import Plot from '@ralphsmith80/solid-plotly.js'
 import type { PlotlyFigure } from '@ralphsmith80/solid-plotly.js'
+import Plot from '@ralphsmith80/solid-plotly.js'
 import type { PlotType } from 'plotly.js'
+import { createSignal } from 'solid-js'
 
 export const Chart = () => {
-  const [data] = createSignal<Partial<Plotly.PlotData>[]>([
+  const [data, setData] = createSignal<Partial<Plotly.PlotData>[]>([
     {
       x: [1, 2, 3, 4],
       y: [10, 15, 13, 17],
@@ -15,7 +15,7 @@ export const Chart = () => {
     },
   ])
 
-  const [layout] = createSignal<PlotlyFigure['layout']>({
+  const [layout, setLayout] = createSignal<PlotlyFigure['layout']>({
     title: 'A Simple Plot',
   })
 
@@ -34,6 +34,19 @@ export const Chart = () => {
   const handlePurge = () => {
     console.log('Plotly chart purged.')
   }
+
+  setTimeout(() => {
+    setLayout({ title: 'A Simple Plat' })
+    setData([
+      {
+        x: [1, 2, 3, 4],
+        y: [15, 10, 17, 13],
+        type: 'scatter' as PlotType,
+        mode: 'lines+markers',
+        marker: { color: 'blue' },
+      },
+    ])
+  }, 1000)
 
   return (
     <Plot

--- a/packages/solid-plotly.js/src/factory.tsx
+++ b/packages/solid-plotly.js/src/factory.tsx
@@ -123,11 +123,13 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
         updatePlotly(props.onInitialized)
         createEffect(() => updatePlotly(props.onUpdate), { defer: true })
 
-        if (isBrowser && props.useResizeHandler) {
-          const resizeHandler = () => el && Plotly.Plots.resize(el)
-          window.addEventListener('resize', resizeHandler)
-          onCleanup(() => window.removeEventListener('resize', resizeHandler))
-        }
+        createEffect(() => {
+          if (isBrowser && props.useResizeHandler) {
+            const resizeHandler = () => el && Plotly.Plots.resize(el)
+            window.addEventListener('resize', resizeHandler)
+            onCleanup(() => window.removeEventListener('resize', resizeHandler))
+          }
+        })
 
         onCleanup(() => {
           props.onPurge?.()

--- a/packages/solid-plotly.js/src/factory.tsx
+++ b/packages/solid-plotly.js/src/factory.tsx
@@ -120,8 +120,12 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
       onMount(() => {
         initEventHandlers()
         initUpdateEvents()
-        updatePlotly(props.onInitialized)
-        createEffect(() => updatePlotly(props.onUpdate), { defer: true })
+
+        let initialized = false
+        createEffect(() => {
+          updatePlotly(!initialized ? props.onInitialized : props.onUpdate)
+          initialized = true
+        })
 
         createEffect(() => {
           if (isBrowser && props.useResizeHandler) {

--- a/packages/solid-plotly.js/src/factory.tsx
+++ b/packages/solid-plotly.js/src/factory.tsx
@@ -146,11 +146,5 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
     )
   }
 
-  PlotlyComponent.defaultProps = {
-    useResizeHandler: false,
-    data: [],
-    style: { position: 'relative', display: 'inline-block' } as const,
-  }
-
   return PlotlyComponent
 }

--- a/packages/solid-plotly.js/src/factory.tsx
+++ b/packages/solid-plotly.js/src/factory.tsx
@@ -89,7 +89,7 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
             if (handler && isBasicEvent(plotlyEventName)) {
               const handle = () => handler(getCurrentFigure(), el)
               el.on(plotlyEventName, handle)
-              onCleanup(() => el?.removeListener(plotlyEventName, handle))
+              onCleanup(() => el.removeListener(plotlyEventName, handle))
             }
           })
         })
@@ -97,9 +97,9 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
 
       const getCurrentFigure = (): PlotlyFigure => {
         return {
-          data: el?.data as Partial<PlotData>[],
-          layout: el?.layout ?? {},
-          frames: el?._transitionData?._frames,
+          data: el.data as Partial<PlotData>[],
+          layout: el.layout ?? {},
+          frames: el._transitionData?._frames,
         }
       }
 
@@ -125,7 +125,7 @@ export default function plotComponentFactory(Plotly: typeof PlotlyInstance) {
 
         createEffect(() => {
           if (isBrowser && props.useResizeHandler) {
-            const resizeHandler = () => el && Plotly.Plots.resize(el)
+            const resizeHandler = () => Plotly.Plots.resize(el)
             window.addEventListener('resize', resizeHandler)
             onCleanup(() => window.removeEventListener('resize', resizeHandler))
           }


### PR DESCRIPTION
made some updates to the code to follow more conventional solid patterns

changes: 
- not manually tracking/diffing update-event handlers, but use effects instead (`syncEventHandlers` becomes `initEventHandlers`)
- initialise resize event on mount (`syncWindowsResize` becomes `initWindowsResize`)
- remove dependency-array and use solid's auto-tracking instead
- removed `plotEl` and replaced it with `onRef`: all the logic is moved in this handle.
- removed `retryUpdatePlotly`, since the element will be defined in `onRef` and mounted to the page in `onMount`.

tested it out locally and seems to work in-brower: 

https://github.com/user-attachments/assets/445176bf-afbd-45e9-bcf2-a186bf1828fc

haven't checked ssr stuff, but since all logic is called in `onMount` i suppose it will be fine.
